### PR TITLE
Wrong line endings were used when communicating with the post_office mail server

### DIFF
--- a/lib/generic_server.rb
+++ b/lib/generic_server.rb
@@ -55,7 +55,7 @@ class GenericServer
   # Respond to client by sending back text
   def respond(client, text)
     puts "#{client.object_id}:#{@port} > #{text}"
-    client.puts text
+    client.write text
   rescue
     puts "#{client.object_id}:#{@port} ! #{$!}"
     client.close

--- a/lib/smtp_server.rb
+++ b/lib/smtp_server.rb
@@ -104,7 +104,7 @@ class SMTPServer < GenericServer
   
   # Respond to client using a standard SMTP response code
   def respond(client, code)
-    super(client, "#{code} #{SMTPServer::RESPONSES[code].to_s}")
+    super(client, "#{code} #{SMTPServer::RESPONSES[code].to_s}\r\n")
   end
   
   # Standard SMTP response codes


### PR DESCRIPTION
I couldn't sent email with my Apple Mail client. The SMTP server didn't respond correctly .
Changed the response.puts call to respones.write to prevent the wrong/double line endings.
