### PR TITLE
load a config file and move default options (to become more DRY)

### DIFF
--- a/bin/post_office
+++ b/bin/post_office
@@ -11,7 +11,7 @@ require 'pop_server.rb'
 # Parse command line arguments
 #
 options = {}
- 
+
 optparse = OptionParser.new do |opts|
   opts.banner = "Usage: #{__FILE__} [options]"
 
@@ -25,16 +25,16 @@ optparse = OptionParser.new do |opts|
     options[:logfile] = file
   end
 
-  options[:smtp_port] = nil
+  options[:smtp_port] = 25
   opts.on( '-s', '--smtp PORT', 'Specify SMTP port to use' ) do |port|
     options[:smtp_port] = port
   end
 
-  options[:pop3_port] = nil
+  options[:pop3_port] = 110
   opts.on( '-p', '--pop3 PORT', 'Specify POP3 port to use' ) do |port|
     options[:pop3_port] = port
   end
-  
+
   options[:startup_item] = nil
   opts.on('--install-osx-startup-item', 'Installs Post Office as OS X Startup Item') do
     options[:startup_item] = :install
@@ -71,14 +71,14 @@ $log.level = options[:verbose] ? Logger::DEBUG : Logger::INFO
 $log.datetime_format = "%H:%M:%S"
 
 begin
-  smtp_server = Thread.new{ SMTPServer.new(options[:smtp_port] || 25) }
-  pop_server  = Thread.new{ POPServer.new(options[:pop3_port] || 110) }
+  smtp_server = Thread.new{ SMTPServer.new(options[:smtp_port]) }
+  pop_server  = Thread.new{ POPServer.new(options[:pop3_port]) }
 
   smtp_server.join
   pop_server.join
 rescue Interrupt
   $log.info "Interrupt..."
 rescue Errno::EACCES
-  $log.error "I need root access to open ports #{options[:smtp_port] || 25} and / or #{options[:pop3_port] || 110}. Please sudo #{__FILE__}"
+  $log.error "I need root access to open ports #{options[:smtp_port]} and / or #{options[:pop3_port]}. Please sudo #{__FILE__}"
 end
 

--- a/bin/post_office
+++ b/bin/post_office
@@ -7,30 +7,49 @@ require 'thread'
 require 'smtp_server.rb'
 require 'pop_server.rb'
 
+def config_filename(base_dir)
+  "#{base_dir}/post_office/config.yml"
+end
+
+def config_home
+  ENV.fetch('XDG_CONFIG_HOME', ENV['HOME'] + '/.config')
+end
+
+def detect_config_file
+  local = config_filename(config_home)
+  global = config_filename('/etc')
+  [local, global].detect { |filename| File.exist? filename }
+end
+
+def read_config_file(config_file = detect_config_file)
+  return {} if config_file.nil?
+  YAML.load_file(config_file)
+end
+
 #
 # Parse command line arguments
 #
-options = {}
+options = read_config_file
 
 optparse = OptionParser.new do |opts|
   opts.banner = "Usage: #{__FILE__} [options]"
 
-  options[:verbose] = false
+  options[:verbose] ||= false
   opts.on( '-v', '--verbose', 'Output more information' ) do
     options[:verbose] = true
   end
 
-  options[:logfile] = nil
+  options[:logfile] ||= nil
   opts.on( '-l', '--logfile FILE', 'Write log to FILE. Outputs to STDOUT (or /var/log/post_office.log when daemonized) by default.' ) do |file|
     options[:logfile] = file
   end
 
-  options[:smtp_port] = 25
+  options[:smtp_port] ||= 25
   opts.on( '-s', '--smtp PORT', 'Specify SMTP port to use' ) do |port|
     options[:smtp_port] = port
   end
 
-  options[:pop3_port] = 110
+  options[:pop3_port] ||= 110
   opts.on( '-p', '--pop3 PORT', 'Specify POP3 port to use' ) do |port|
     options[:pop3_port] = port
   end
@@ -39,6 +58,7 @@ optparse = OptionParser.new do |opts|
   opts.on('--install-osx-startup-item', 'Installs Post Office as OS X Startup Item') do
     options[:startup_item] = :install
   end
+
   opts.on('--remove-osx-startup-item', 'Removes Post Office as OS X Startup Item') do
     options[:startup_item] = :remove
   end

--- a/bin/post_office
+++ b/bin/post_office
@@ -4,30 +4,11 @@ $LOAD_PATH.unshift File.dirname(__FILE__) + '/../lib'
 require 'optparse'
 require 'logger'
 require 'thread'
-require 'json'
 require 'smtp_server.rb'
 require 'pop_server.rb'
+require 'config_file.rb'
 
-def config_filename(base_dir)
-  "#{base_dir}/post_office/config.json"
-end
-
-def config_home
-  ENV.fetch('XDG_CONFIG_HOME', ENV['HOME'] + '/.config')
-end
-
-def detect_config_file
-  local = config_filename(config_home)
-  global = config_filename('/etc')
-  [local, global].detect { |filename| File.exist? filename }
-end
-
-def read_config_file(config_file = detect_config_file)
-  return {} if config_file.nil?
-  JSON.parse(File.read(config_file), symbolize_names: true)
-end
-
-options = read_config_file
+options = ConfigFile.detect.read
 
 #
 # Parse command line arguments

--- a/bin/post_office
+++ b/bin/post_office
@@ -4,11 +4,12 @@ $LOAD_PATH.unshift File.dirname(__FILE__) + '/../lib'
 require 'optparse'
 require 'logger'
 require 'thread'
+require 'json'
 require 'smtp_server.rb'
 require 'pop_server.rb'
 
 def config_filename(base_dir)
-  "#{base_dir}/post_office/config.yml"
+  "#{base_dir}/post_office/config.json"
 end
 
 def config_home
@@ -23,14 +24,14 @@ end
 
 def read_config_file(config_file = detect_config_file)
   return {} if config_file.nil?
-  YAML.load_file(config_file)
+  JSON.parse(File.read(config_file), symbolize_names: true)
 end
+
+options = read_config_file
 
 #
 # Parse command line arguments
 #
-options = read_config_file
-
 optparse = OptionParser.new do |opts|
   opts.banner = "Usage: #{__FILE__} [options]"
 

--- a/lib/config_file.rb
+++ b/lib/config_file.rb
@@ -1,0 +1,24 @@
+require 'json'
+
+class ConfigFile
+  USER_CONFIG_DIR = ENV.fetch('XDG_CONFIG_HOME', ENV['HOME'] + '/.config')
+  SYSTEM_CONFIG_DIR = '/etc'
+  CONFIG_DIRS = [USER_CONFIG_DIR, SYSTEM_CONFIG_DIR]
+  attr_reader :filename
+
+  def initialize(filename)
+    @filename = filename
+  end
+
+  def self.detect
+    filename =
+      CONFIG_DIRS.map { |dir| "#{dir}/post_office/config.json" }
+                 .detect { |file| File.exist? file }
+    new(filename)
+  end
+
+  def read
+    return {} if @filename.nil?
+    JSON.parse(File.read(@filename), symbolize_names: true)
+  end
+end


### PR DESCRIPTION
I moved the logic that sets the default ports up to the option parser block to remove some duplication. 

Then I added a bit of code to load settings from a file. The arguments passed on the command line will always override the ones specified in the config file. It will try to find a configuration file in the user dir (`$HOME`), and then in `/etc`. It will load the first one it finds.